### PR TITLE
Redo re.compile() implementation wihout json

### DIFF
--- a/hashid.py
+++ b/hashid.py
@@ -32,13 +32,13 @@ HashMode = namedtuple('HashMode', ['name', 'hashcat', 'extended'])
 
 prototypes = [
     Prototype(
-        regex=r'^[a-f0-9]{4}$',
+        regex=re.compile(r'^[a-f0-9]{4}$', re.IGNORECASE),
         modes=[
             HashMode(name='CRC-16', hashcat=None, extended=False),
             HashMode(name='CRC-16-CCITT', hashcat=None, extended=False),
             HashMode(name='FCS-16', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{8}$',
+        regex=re.compile(r'^[a-f0-9]{8}$', re.IGNORECASE),
         modes=[
             HashMode(name='Adler-32', hashcat=None, extended=False),
             HashMode(name='CRC-32', hashcat=None, extended=False),
@@ -52,21 +52,21 @@ prototypes = [
             HashMode(name='ELF-32', hashcat=None, extended=False),
             HashMode(name='XOR-32', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{6}$',
+        regex=re.compile(r'^[a-f0-9]{6}$', re.IGNORECASE),
         modes=[
             HashMode(name='CRC-24', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\+[a-z0-9\/\.]{12}$',
+        regex=re.compile(r'^\+[a-z0-9\/\.]{12}$', re.IGNORECASE),
         modes=[
             HashMode(name='Eggdrop IRC Bot', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9\/\.]{13}$',
+        regex=re.compile(r'^[a-z0-9\/\.]{13}$', re.IGNORECASE),
         modes=[
             HashMode(name='DES(Unix)', hashcat=1500, extended=False),
             HashMode(name='Traditional DES', hashcat=1500, extended=False),
             HashMode(name='DEScrypt', hashcat=1500, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{16}$',
+        regex=re.compile(r'^[a-f0-9]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='MySQL323', hashcat=200, extended=False),
             HashMode(name='DES(Oracle)', hashcat=3100, extended=False),
@@ -75,27 +75,27 @@ prototypes = [
             HashMode(name='FNV-164', hashcat=None, extended=False),
             HashMode(name='CRC-64', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9\/\.]{16}$',
+        regex=re.compile(r'^[a-z0-9\/\.]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='Cisco-PIX(MD5)', hashcat=2400, extended=False)]),
     Prototype(
-        regex=r'^\([a-z0-9\+\/]{20}\)$',
+        regex=re.compile(r'^\([a-z0-9\+\/]{20}\)$', re.IGNORECASE),
         modes=[
             HashMode(name='Lotus Notes/Domino 6', hashcat=8700, extended=False)]),
     Prototype(
-        regex=r'^_[a-z0-9\/\.]{19}$',
+        regex=re.compile(r'^_[a-z0-9\/\.]{19}$', re.IGNORECASE),
         modes=[
             HashMode(name='BSDi Crypt', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{24}$',
+        regex=re.compile(r'^[a-f0-9]{24}$', re.IGNORECASE),
         modes=[
             HashMode(name='CRC-96(ZIP)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9\/\.]{24}$',
+        regex=re.compile(r'^[a-z0-9\/\.]{24}$', re.IGNORECASE),
         modes=[
             HashMode(name='Crypt16', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}$',
+        regex=re.compile(r'^[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='MD5', hashcat=0, extended=False),
             HashMode(name='MD4', hashcat=900, extended=False),
@@ -115,7 +115,7 @@ prototypes = [
             HashMode(name='md5(strtoupper(md5($pass)))', hashcat=4300, extended=True),
             HashMode(name='md5(sha1($pass))', hashcat=4400, extended=True)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}(:.+)$',
+        regex=re.compile(r'^[a-f0-9]{32}(:.+)$', re.IGNORECASE),
         modes=[
             HashMode(name='md5($pass.$salt)', hashcat=10, extended=True),
             HashMode(name='md5($salt.$pass)', hashcat=20, extended=True),
@@ -132,80 +132,80 @@ prototypes = [
             HashMode(name='md5($salt.md5($pass.$salt))', hashcat=4110, extended=True),
             HashMode(name='md5($username.0.$pass)', hashcat=4210, extended=True)]),
     Prototype(
-        regex=r'^(\$NT\$)?[a-f0-9]{32}$',
+        regex=re.compile(r'^(\$NT\$)?[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='NTLM', hashcat=1000, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}(:[^\\\/\:\*\?\"\<\>\|]{1,20})?$',
+        regex=re.compile(r'^[a-f0-9]{32}(:[^\\\/\:\*\?\"\<\>\|]{1,20})?$', re.IGNORECASE),
         modes=[
             HashMode(name='Domain Cached Credentials', hashcat=1100, extended=False),
             HashMode(name='mscash', hashcat=1100, extended=True)]),
     Prototype(
-        regex=r'^(\$DCC2\$10240#[^\\\/\:\*\?\"\<\>\|]{1,20}#)?[a-f0-9]{32}$',
+        regex=re.compile(r'^(\$DCC2\$10240#[^\\\/\:\*\?\"\<\>\|]{1,20}#)?[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='Domain Cached Credentials 2', hashcat=2100, extended=False),
             HashMode(name='mscash2', hashcat=2100, extended=True)]),
     Prototype(
-        regex=r'^{SHA}[a-z0-9\+\/=]{28}$',
+        regex=re.compile(r'^{SHA}[a-z0-9\+\/=]{28}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-1(Base64)', hashcat=101, extended=False),
             HashMode(name='Netscape LDAP SHA', hashcat=101, extended=False),
             HashMode(name='nsldap', hashcat=101, extended=True)]),
     Prototype(
-        regex=r'^\$1\$[a-z0-9\/\.]{0,8}\$[a-z0-9\/\.]{22}$',
+        regex=re.compile(r'^\$1\$[a-z0-9\/\.]{0,8}\$[a-z0-9\/\.]{22}$', re.IGNORECASE),
         modes=[
             HashMode(name='MD5 Crypt', hashcat=500, extended=False),
             HashMode(name='Cisco-IOS(MD5)', hashcat=500, extended=False),
             HashMode(name='FreeBSD MD5', hashcat=500, extended=False)]),
     Prototype(
-        regex=r'^0x[a-f0-9]{32}$',
+        regex=re.compile(r'^0x[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='Lineage II C4', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$H\$[a-z0-9\/\.]{31}$',
+        regex=re.compile(r'^\$H\$[a-z0-9\/\.]{31}$', re.IGNORECASE),
         modes=[
             HashMode(name='phpBB v3.x', hashcat=400, extended=False),
             HashMode(name='Wordpress v2.6.0/2.6.1', hashcat=400, extended=False),
             HashMode(name="PHPass' Portable Hash", hashcat=400, extended=False)]),
     Prototype(
-        regex=r'^\$P\$[a-z0-9\/\.]{31}$',
+        regex=re.compile(r'^\$P\$[a-z0-9\/\.]{31}$', re.IGNORECASE),
         modes=[
-            HashMode(name='Wordpress ≥ v2.6.2', hashcat=400, extended=False),
-            HashMode(name='Joomla ≥ v2.5.18', hashcat=400, extended=False),
+            HashMode(name=u'Wordpress ≥ v2.6.2', hashcat=400, extended=False),
+            HashMode(name=u'Joomla ≥ v2.5.18', hashcat=400, extended=False),
             HashMode(name="PHPass' Portable Hash", hashcat=400, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:[a-z0-9]{2}$',
+        regex=re.compile(r'^[a-f0-9]{32}:[a-z0-9]{2}$', re.IGNORECASE),
         modes=[
             HashMode(name='osCommerce', hashcat=21, extended=False),
             HashMode(name='xt:Commerce', hashcat=21, extended=False)]),
     Prototype(
-        regex=r'^\$apr1\$[a-z0-9\/\.]{0,8}\$[a-z0-9\/\.]{22}$',
+        regex=re.compile(r'^\$apr1\$[a-z0-9\/\.]{0,8}\$[a-z0-9\/\.]{22}$', re.IGNORECASE),
         modes=[
             HashMode(name='MD5(APR)', hashcat=1600, extended=False),
             HashMode(name='Apache MD5', hashcat=1600, extended=False),
             HashMode(name='md5apr1', hashcat=1600, extended=True)]),
     Prototype(
-        regex=r'^{smd5}[a-z0-9\.\$]{31}$',
+        regex=re.compile(r'^{smd5}[a-z0-9\.\$]{31}$', re.IGNORECASE),
         modes=[
             HashMode(name='AIX(smd5)', hashcat=6300, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:[a-f0-9]{32}$',
+        regex=re.compile(r'^[a-f0-9]{32}:[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='WebEdition CMS', hashcat=3721, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:.{5}$',
+        regex=re.compile(r'^[a-f0-9]{32}:.{5}$', re.IGNORECASE),
         modes=[
-            HashMode(name='IP.Board ≥ v2+', hashcat=2811, extended=False)]),
+            HashMode(name=u'IP.Board ≥ v2+', hashcat=2811, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:.{8}$',
+        regex=re.compile(r'^[a-f0-9]{32}:.{8}$', re.IGNORECASE),
         modes=[
-            HashMode(name='MyBB ≥ v1.2+', hashcat=2811, extended=False)]),
+            HashMode(name=u'MyBB ≥ v1.2+', hashcat=2811, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9]{34}$',
+        regex=re.compile(r'^[a-z0-9]{34}$', re.IGNORECASE),
         modes=[
             HashMode(name='CryptoCurrency(Adress)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}$',
+        regex=re.compile(r'^[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-1', hashcat=100, extended=False),
             HashMode(name='Double SHA-1', hashcat=4500, extended=False),
@@ -220,7 +220,7 @@ prototypes = [
             HashMode(name='sha1(sha1(sha1($pass)))', hashcat=4600, extended=True),
             HashMode(name='sha1(md5($pass))', hashcat=4700, extended=True)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}(:.+)$',
+        regex=re.compile(r'^[a-f0-9]{40}(:.+)$', re.IGNORECASE),
         modes=[
             HashMode(name='sha1($pass.$salt)', hashcat=110, extended=True),
             HashMode(name='sha1($salt.$pass)', hashcat=120, extended=True),
@@ -229,26 +229,26 @@ prototypes = [
             HashMode(name='HMAC-SHA1 (key = $pass)', hashcat=150, extended=True),
             HashMode(name='HMAC-SHA1 (key = $salt)', hashcat=160, extended=True)]),
     Prototype(
-        regex=r'^\*[a-f0-9]{40}$',
+        regex=re.compile(r'^\*[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='MySQL5.x', hashcat=300, extended=False),
             HashMode(name='MySQL4.1', hashcat=300, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9]{43}$',
+        regex=re.compile(r'^[a-z0-9]{43}$', re.IGNORECASE),
         modes=[
             HashMode(name='Cisco-IOS(SHA-256)', hashcat=5700, extended=False)]),
     Prototype(
-        regex=r'^{SSHA}[a-z0-9\+\/=]{40}$',
+        regex=re.compile(r'^{SSHA}[a-z0-9\+\/=]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='SSHA-1(Base64)', hashcat=111, extended=False),
             HashMode(name='Netscape LDAP SSHA', hashcat=111, extended=False),
             HashMode(name='nsldaps', hashcat=111, extended=True)]),
     Prototype(
-        regex=r'^[a-z0-9]{47}$',
+        regex=re.compile(r'^[a-z0-9]{47}$', re.IGNORECASE),
         modes=[
             HashMode(name='Fortigate(FortiOS)', hashcat=7000, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{48}$',
+        regex=re.compile(r'^[a-f0-9]{48}$', re.IGNORECASE),
         modes=[
             HashMode(name='Haval-192', hashcat=None, extended=False),
             HashMode(name='Tiger-192', hashcat=None, extended=False),
@@ -257,28 +257,28 @@ prototypes = [
             HashMode(name='OSX v10.5', hashcat=122, extended=False),
             HashMode(name='OSX v10.6', hashcat=122, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{51}$',
+        regex=re.compile(r'^[a-f0-9]{51}$', re.IGNORECASE),
         modes=[
             HashMode(name='Palshop CMS', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9]{51}$',
+        regex=re.compile(r'^[a-z0-9]{51}$', re.IGNORECASE),
         modes=[
             HashMode(name='CryptoCurrency(PrivateKey)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^{ssha1}[a-z0-9\.\$]{47}$',
+        regex=re.compile(r'^{ssha1}[a-z0-9\.\$]{47}$', re.IGNORECASE),
         modes=[
             HashMode(name='AIX(ssha1)', hashcat=6700, extended=False)]),
     Prototype(
-        regex=r'^0x0100[a-f0-9]{48}$',
+        regex=re.compile(r'^0x0100[a-f0-9]{48}$', re.IGNORECASE),
         modes=[
             HashMode(name='MSSQL(2005)', hashcat=132, extended=False),
             HashMode(name='MSSQL(2008)', hashcat=132, extended=False)]),
     Prototype(
-        regex=r'^(\$md5,rounds=[0-9]+\$|\$md5\$rounds=[0-9]+\$|\$md5\$)[a-z0-9\/\.]{0,16}(\$|\$\$)[a-z0-9\/\.]{22}$',
+        regex=re.compile(r'^(\$md5,rounds=[0-9]+\$|\$md5\$rounds=[0-9]+\$|\$md5\$)[a-z0-9\/\.]{0,16}(\$|\$\$)[a-z0-9\/\.]{22}$', re.IGNORECASE),
         modes=[
             HashMode(name='Sun MD5 Crypt', hashcat=3300, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{56}$',
+        regex=re.compile(r'^[a-f0-9]{56}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-224', hashcat=None, extended=False),
             HashMode(name='Haval-224', hashcat=None, extended=False),
@@ -286,33 +286,33 @@ prototypes = [
             HashMode(name='Skein-256(224)', hashcat=None, extended=False),
             HashMode(name='Skein-512(224)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^(\$2[axy]|\$2)\$[0-9]{0,2}?\$[a-z0-9\/\.]{53}$',
+        regex=re.compile(r'^(\$2[axy]|\$2)\$[0-9]{0,2}?\$[a-z0-9\/\.]{53}$', re.IGNORECASE),
         modes=[
             HashMode(name='Blowfish(OpenBSD)', hashcat=3200, extended=False),
             HashMode(name='Woltlab Burning Board 4.x', hashcat=None, extended=False),
             HashMode(name='BCrypt', hashcat=3200, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}:[a-f0-9]{16}$',
+        regex=re.compile(r'^[a-f0-9]{40}:[a-f0-9]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='Samsung Android Password/PIN', hashcat=5800, extended=False)]),
     Prototype(
-        regex=r'^S:[a-f0-9]{60}$',
+        regex=re.compile(r'^S:[a-f0-9]{60}$', re.IGNORECASE),
         modes=[
             HashMode(name='Oracle 11g', hashcat=112, extended=False)]),
     Prototype(
-        regex=r'^\$bcrypt-sha256\$(2[axy]|2)\,[0-9]+\$[a-z0-9\/\.]{22}\$[a-z0-9\/\.]{31}$',
+        regex=re.compile(r'^\$bcrypt-sha256\$(2[axy]|2)\,[0-9]+\$[a-z0-9\/\.]{22}\$[a-z0-9\/\.]{31}$', re.IGNORECASE),
         modes=[
             HashMode(name='BCrypt(SHA-256)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:.{3}$',
+        regex=re.compile(r'^[a-f0-9]{32}:.{3}$', re.IGNORECASE),
         modes=[
             HashMode(name='vBulletin < v3.8.5', hashcat=2611, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:.{30}$',
+        regex=re.compile(r'^[a-f0-9]{32}:.{30}$', re.IGNORECASE),
         modes=[
-            HashMode(name='vBulletin ≥ v3.8.5', hashcat=2711, extended=False)]),
+            HashMode(name=u'vBulletin ≥ v3.8.5', hashcat=2711, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{64}$',
+        regex=re.compile(r'^[a-f0-9]{64}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-256', hashcat=1400, extended=False),
             HashMode(name='RIPEMD-256', hashcat=None, extended=False),
@@ -324,7 +324,7 @@ prototypes = [
             HashMode(name='Skein-512(256)', hashcat=None, extended=False),
             HashMode(name='Ventrilo', hashcat=None, extended=True)]),
     Prototype(
-        regex=r'^[a-f0-9]{64}(:.+)$',
+        regex=re.compile(r'^[a-f0-9]{64}(:.+)$', re.IGNORECASE),
         modes=[
             HashMode(name='sha256($pass.$salt)', hashcat=1410, extended=True),
             HashMode(name='sha256($salt.$pass)', hashcat=1420, extended=True),
@@ -333,56 +333,56 @@ prototypes = [
             HashMode(name='HMAC-SHA256 (key = $pass)', hashcat=1450, extended=True),
             HashMode(name='HMAC-SHA256 (key = $salt)', hashcat=1460, extended=True)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:[a-z0-9]{32}$',
+        regex=re.compile(r'^[a-f0-9]{32}:[a-z0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='Joomla < v2.5.18', hashcat=11, extended=False)]),
     Prototype(
-        regex=r'^[a-f-0-9]{32}:[a-f-0-9]{32}$',
+        regex=re.compile(r'^[a-f-0-9]{32}:[a-f-0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='SAM(LM_Hash:NT_Hash)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:[0-9]{32}:[0-9]{2}$',
+        regex=re.compile(r'^[a-f0-9]{32}:[0-9]{32}:[0-9]{2}$', re.IGNORECASE),
         modes=[
             HashMode(name='MD5(Chap)', hashcat=4800, extended=False),
             HashMode(name='iSCSI CHAP Authentication', hashcat=4800, extended=False)]),
     Prototype(
-        regex=r'^\$episerver\$\*0\*[a-z0-9=\*\+]{52}$',
+        regex=re.compile(r'^\$episerver\$\*0\*[a-z0-9=\*\+]{52}$', re.IGNORECASE),
         modes=[
             HashMode(name='EPiServer 6.x < v4', hashcat=141, extended=False)]),
     Prototype(
-        regex=r'^{ssha256}[a-z0-9\.\$]{63}$',
+        regex=re.compile(r'^{ssha256}[a-z0-9\.\$]{63}$', re.IGNORECASE),
         modes=[
             HashMode(name='AIX(ssha256)', hashcat=6400, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{80}$',
+        regex=re.compile(r'^[a-f0-9]{80}$', re.IGNORECASE),
         modes=[
             HashMode(name='RIPEMD-320', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$episerver\$\*1\*[a-z0-9=\*\+]{68}$',
+        regex=re.compile(r'^\$episerver\$\*1\*[a-z0-9=\*\+]{68}$', re.IGNORECASE),
         modes=[
-            HashMode(name='EPiServer 6.x ≥ v4', hashcat=1441, extended=False)]),
+            HashMode(name=u'EPiServer 6.x ≥ v4', hashcat=1441, extended=False)]),
     Prototype(
-        regex=r'^0x0100[a-f0-9]{88}$',
+        regex=re.compile(r'^0x0100[a-f0-9]{88}$', re.IGNORECASE),
         modes=[
             HashMode(name='MSSQL(2000)', hashcat=131, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{96}$',
+        regex=re.compile(r'^[a-f0-9]{96}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-384', hashcat=None, extended=False),
             HashMode(name='SHA3-384', hashcat=None, extended=False),
             HashMode(name='Skein-512(384)', hashcat=None, extended=False),
             HashMode(name='Skein-1024(384)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^{SSHA512}[a-z0-9\+\/]{96}={0,2}$',
+        regex=re.compile(r'^{SSHA512}[a-z0-9\+\/]{96}={0,2}$', re.IGNORECASE),
         modes=[
             HashMode(name='SSHA-512(Base64)', hashcat=1711, extended=False),
             HashMode(name='LDAP(SSHA-512)', hashcat=1711, extended=False)]),
     Prototype(
-        regex=r'^{ssha512}[0-9]{2}\$[a-z0-9\.\/]{16,48}\$[a-z0-9\.\/]{86}$',
+        regex=re.compile(r'^{ssha512}[0-9]{2}\$[a-z0-9\.\/]{16,48}\$[a-z0-9\.\/]{86}$', re.IGNORECASE),
         modes=[
             HashMode(name='AIX(ssha512)', hashcat=6500, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{128}$',
+        regex=re.compile(r'^[a-f0-9]{128}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-512', hashcat=1700, extended=False),
             HashMode(name='Whirlpool', hashcat=6100, extended=False),
@@ -392,7 +392,7 @@ prototypes = [
             HashMode(name='Skein-512', hashcat=None, extended=False),
             HashMode(name='Skein-1024(512)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{128}(:.+)$',
+        regex=re.compile(r'^[a-f0-9]{128}(:.+)$', re.IGNORECASE),
         modes=[
             HashMode(name='sha512($pass.$salt)', hashcat=1710, extended=True),
             HashMode(name='sha512($salt.$pass)', hashcat=1720, extended=True),
@@ -401,221 +401,221 @@ prototypes = [
             HashMode(name='HMAC-SHA512 (key = $pass)', hashcat=1750, extended=True),
             HashMode(name='HMAC-SHA512 (key = $salt)', hashcat=1760, extended=True)]),
     Prototype(
-        regex=r'^[a-f0-9]{136}$',
+        regex=re.compile(r'^[a-f0-9]{136}$', re.IGNORECASE),
         modes=[
             HashMode(name='OSX v10.7', hashcat=1722, extended=False)]),
     Prototype(
-        regex=r'^0x0200[a-f0-9]{136}$',
+        regex=re.compile(r'^0x0200[a-f0-9]{136}$', re.IGNORECASE),
         modes=[
             HashMode(name='MSSQL(2012)', hashcat=1731, extended=False),
             HashMode(name='MSSQL(2014)', hashcat=1731, extended=False)]),
     Prototype(
-        regex=r'^\$ml\$[0-9]+\$[a-f0-9]{64}\$[a-f0-9]{128}$',
+        regex=re.compile(r'^\$ml\$[0-9]+\$[a-f0-9]{64}\$[a-f0-9]{128}$', re.IGNORECASE),
         modes=[
             HashMode(name='OSX v10.8', hashcat=7100, extended=False),
             HashMode(name='OSX v10.9', hashcat=7100, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{256}$',
+        regex=re.compile(r'^[a-f0-9]{256}$', re.IGNORECASE),
         modes=[
             HashMode(name='Skein-1024', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^grub\.pbkdf2\.sha512\.[0-9]+\.[a-f0-9]{128,2048}\.[a-f0-9]{128}$',
+        regex=re.compile(r'^grub\.pbkdf2\.sha512\.[0-9]+\.[a-f0-9]{128,2048}\.[a-f0-9]{128}$', re.IGNORECASE),
         modes=[
             HashMode(name='GRUB 2', hashcat=7200, extended=False)]),
     Prototype(
-        regex=r'^sha1\$[a-f0-9]{1,}\$[a-f0-9]{40}$',
+        regex=re.compile(r'^sha1\$[a-f0-9]{1,}\$[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(SHA-1)', hashcat=800, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{49}$',
+        regex=re.compile(r'^[a-f0-9]{49}$', re.IGNORECASE),
         modes=[
             HashMode(name='Citrix Netscaler', hashcat=8100, extended=False)]),
     Prototype(
-        regex=r'^\$S\$[a-z0-9\/\.]{52}$',
+        regex=re.compile(r'^\$S\$[a-z0-9\/\.]{52}$', re.IGNORECASE),
         modes=[
             HashMode(name='Drupal > v7.x', hashcat=7900, extended=False)]),
     Prototype(
-        regex=r'^\$5\$(rounds=[0-9]+\$)?[a-z0-9\/\.]{0,16}\$[a-z0-9\/\.]{43}$',
+        regex=re.compile(r'^\$5\$(rounds=[0-9]+\$)?[a-z0-9\/\.]{0,16}\$[a-z0-9\/\.]{43}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-256 Crypt', hashcat=7400, extended=False)]),
     Prototype(
-        regex=r'^0x[a-f0-9]{4}[a-f0-9]{16}[a-f0-9]{64}$',
+        regex=re.compile(r'^0x[a-f0-9]{4}[a-f0-9]{16}[a-f0-9]{64}$', re.IGNORECASE),
         modes=[
             HashMode(name='Sybase ASE', hashcat=8000, extended=False)]),
     Prototype(
-        regex=r'^\$6\$(rounds=[0-9]+\$)?[a-z0-9\/\.]{0,16}\$[a-z0-9\/\.]{86}$',
+        regex=re.compile(r'^\$6\$(rounds=[0-9]+\$)?[a-z0-9\/\.]{0,16}\$[a-z0-9\/\.]{86}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-512 Crypt', hashcat=1800, extended=False)]),
     Prototype(
-        regex=r'^\$sha\$[a-z0-9]{1,16}\$([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64}|[a-f0-9]{128}|[a-f0-9]{140})$',
+        regex=re.compile(r'^\$sha\$[a-z0-9]{1,16}\$([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64}|[a-f0-9]{128}|[a-f0-9]{140})$', re.IGNORECASE),
         modes=[
             HashMode(name='Minecraft(AuthMe Reloaded)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^sha256\$[a-f0-9]{1,}\$[a-f0-9]{64}$',
+        regex=re.compile(r'^sha256\$[a-f0-9]{1,}\$[a-f0-9]{64}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(SHA-256)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^sha384\$[a-f0-9]{1,}\$[a-f0-9]{96}$',
+        regex=re.compile(r'^sha384\$[a-f0-9]{1,}\$[a-f0-9]{96}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(SHA-384)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^crypt1:[a-z0-9\+\=]{12}:[a-z0-9\+\=]{12}$',
+        regex=re.compile(r'^crypt1:[a-z0-9\+\=]{12}:[a-z0-9\+\=]{12}$', re.IGNORECASE),
         modes=[
             HashMode(name='Clavister Secure Gateway', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{112}$',
+        regex=re.compile(r'^[a-f0-9]{112}$', re.IGNORECASE),
         modes=[
             HashMode(name='Cisco VPN Client(PCF-File)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{1329}$',
+        regex=re.compile(r'^[a-f0-9]{1329}$', re.IGNORECASE),
         modes=[
             HashMode(name='Microsoft MSTSC(RDP-File)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[^\\\/:*?\"\<\>\|]{1,20}::[^\\\/:*?\"\<\>\|]{1,20}:[a-f0-9]{48}:[a-f0-9]{48}:[a-f0-9]{16}$',
+        regex=re.compile(r'^[^\\\/:*?\"\<\>\|]{1,20}::[^\\\/:*?\"\<\>\|]{1,20}:[a-f0-9]{48}:[a-f0-9]{48}:[a-f0-9]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='NetNTLMv1-VANILLA / NetNTLMv1+ESS', hashcat=5500, extended=False)]),
     Prototype(
-        regex=r'^[^\\\/:*?\"\<\>\|]{1,20}::[^\\\/:*?\"\<\>\|]{1,20}:[a-f0-9]{16}:[a-f0-9]{32}:[a-f0-9]+$',
+        regex=re.compile(r'^[^\\\/:*?\"\<\>\|]{1,20}::[^\\\/:*?\"\<\>\|]{1,20}:[a-f0-9]{16}:[a-f0-9]{32}:[a-f0-9]+$', re.IGNORECASE),
         modes=[
             HashMode(name='NetNTLMv2', hashcat=5600, extended=False)]),
     Prototype(
-        regex=r'^\$krb5pa\$23\$user\$realm\$salt\$[a-f0-9]{104}$',
+        regex=re.compile(r'^\$krb5pa\$23\$user\$realm\$salt\$[a-f0-9]{104}$', re.IGNORECASE),
         modes=[
             HashMode(name='Kerberos 5 AS-REQ Pre-Auth', hashcat=7500, extended=False)]),
     Prototype(
-        regex=r'^\$scram\$[0-9]+\$[a-z0-9\/\.]{16}\$sha-1=[a-z0-9\/\.]{27},sha-256=[a-z0-9\/\.]{43},sha-512=[a-z0-9\/\.]{86}$',
+        regex=re.compile(r'^\$scram\$[0-9]+\$[a-z0-9\/\.]{16}\$sha-1=[a-z0-9\/\.]{27},sha-256=[a-z0-9\/\.]{43},sha-512=[a-z0-9\/\.]{86}$', re.IGNORECASE),
         modes=[
             HashMode(name='SCRAM Hash', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}:[a-f0-9]{0,32}$',
+        regex=re.compile(r'^[a-f0-9]{40}:[a-f0-9]{0,32}$', re.IGNORECASE),
         modes=[
             HashMode(name='Redmine Project Management Web App', hashcat=7600, extended=False)]),
     Prototype(
-        regex=r'^([0-9]{12})?\$[a-f0-9]{16}$',
+        regex=re.compile(r'^([0-9]{12})?\$[a-f0-9]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='SAP CODVN B (BCODE)', hashcat=7700, extended=False)]),
     Prototype(
-        regex=r'^([0-9]{12})?\$[a-f0-9]{40}$',
+        regex=re.compile(r'^([0-9]{12})?\$[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='SAP CODVN F/G (PASSCODE)', hashcat=7800, extended=False)]),
     Prototype(
-        regex=r'^(.+\$)?[a-z0-9\/\.]{30}(:.+)?$',
+        regex=re.compile(r'^(.+\$)?[a-z0-9\/\.]{30}(:.+)?$', re.IGNORECASE),
         modes=[
             HashMode(name='Juniper Netscreen/SSG(ScreenOS)', hashcat=22, extended=False)]),
     Prototype(
-        regex=r'^0x[a-f0-9]{60}\s0x[a-f0-9]{40}$',
+        regex=re.compile(r'^0x[a-f0-9]{60}\s0x[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='EPi', hashcat=123, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}:[^*]{1,25}$',
+        regex=re.compile(r'^[a-f0-9]{40}:[^*]{1,25}$', re.IGNORECASE),
         modes=[
-            HashMode(name='SMF ≥ v1.1', hashcat=121, extended=False)]),
+            HashMode(name=u'SMF ≥ v1.1', hashcat=121, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{40}:[a-f0-9]{40}$',
+        regex=re.compile(r'^[a-f0-9]{40}:[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='Woltlab Burning Board 3.x', hashcat=8400, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{130}(:[a-f0-9]{40})?$',
+        regex=re.compile(r'^[a-f0-9]{130}(:[a-f0-9]{40})?$', re.IGNORECASE),
         modes=[
             HashMode(name='IPMI2 RAKP HMAC-SHA1', hashcat=7300, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{32}:[0-9]+:[a-z0-9_.+-]+@[a-z0-9-]+\.[a-z0-9-.]+$',
+        regex=re.compile(r'^[a-f0-9]{32}:[0-9]+:[a-z0-9_.+-]+@[a-z0-9-]+\.[a-z0-9-.]+$', re.IGNORECASE),
         modes=[
             HashMode(name='Lastpass', hashcat=6800, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9\/\.]{16}(:.{1,})?$',
+        regex=re.compile(r'^[a-z0-9\/\.]{16}(:.{1,})?$', re.IGNORECASE),
         modes=[
             HashMode(name='Cisco-ASA(MD5)', hashcat=2410, extended=False)]),
     Prototype(
-        regex=r'^\$vnc\$\*[a-f0-9]{32}\*[a-f0-9]{32}$',
+        regex=re.compile(r'^\$vnc\$\*[a-f0-9]{32}\*[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='VNC', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9]{32}(:([a-z0-9-]+\.)?[a-z0-9-.]+\.[a-z]{2,7}:.+:[0-9]+)?$',
+        regex=re.compile(r'^[a-z0-9]{32}(:([a-z0-9-]+\.)?[a-z0-9-.]+\.[a-z]{2,7}:.+:[0-9]+)?$', re.IGNORECASE),
         modes=[
             HashMode(name='DNSSEC(NSEC3)', hashcat=8300, extended=False)]),
     Prototype(
-        regex=r'^(user-.+:)?\$racf\$\*.+\*[a-f0-9]{16}$',
+        regex=re.compile(r'^(user-.+:)?\$racf\$\*.+\*[a-f0-9]{16}$', re.IGNORECASE),
         modes=[
             HashMode(name='RACF', hashcat=8500, extended=False)]),
     Prototype(
-        regex=r'^\$3\$\$[a-f0-9]{32}$',
+        regex=re.compile(r'^\$3\$\$[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='NTHash(FreeBSD Variant)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$sha1\$[0-9]+\$[a-z0-9\/\.]{0,64}\$[a-z0-9\/\.]{28}$',
+        regex=re.compile(r'^\$sha1\$[0-9]+\$[a-z0-9\/\.]{0,64}\$[a-z0-9\/\.]{28}$', re.IGNORECASE),
         modes=[
             HashMode(name='SHA-1 Crypt', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{70}$',
+        regex=re.compile(r'^[a-f0-9]{70}$', re.IGNORECASE),
         modes=[
             HashMode(name='hMailServer', hashcat=1421, extended=False)]),
     Prototype(
-        regex=r'^[:\$][AB][:\$]([a-f0-9]{1,8}[:\$])?[a-f0-9]{32}$',
+        regex=re.compile(r'^[:\$][AB][:\$]([a-f0-9]{1,8}[:\$])?[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='MediaWiki', hashcat=3711, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{140}$',
+        regex=re.compile(r'^[a-f0-9]{140}$', re.IGNORECASE),
         modes=[
             HashMode(name='Minecraft(xAuth)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$pbkdf2-sha(1|256|512)\$[0-9]+\$[a-z0-9\/\.]{22}\$([a-z0-9\/\.]{27}|[a-z0-9\/\.]{43}|[a-z0-9\/\.]{86})$',
+        regex=re.compile(r'^\$pbkdf2-sha(1|256|512)\$[0-9]+\$[a-z0-9\/\.]{22}\$([a-z0-9\/\.]{27}|[a-z0-9\/\.]{43}|[a-z0-9\/\.]{86})$', re.IGNORECASE),
         modes=[
             HashMode(name='PBKDF2(Generic)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$p5k2\$[0-9]+\$[a-z0-9\/+=-]+\$[a-z0-9\/+=-]{28}$',
+        regex=re.compile(r'^\$p5k2\$[0-9]+\$[a-z0-9\/+=-]+\$[a-z0-9\/+=-]{28}$', re.IGNORECASE),
         modes=[
             HashMode(name='PBKDF2(Cryptacular)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$p5k2\$[0-9]+\$[a-z0-9\/\.]+\$[a-z0-9\/\.]{32}$',
+        regex=re.compile(r'^\$p5k2\$[0-9]+\$[a-z0-9\/\.]+\$[a-z0-9\/\.]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='PBKDF2(Dwayne Litzenberger)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^{FSHP[0123]\|[0-9]+\|[0-9]+}[a-z0-9\/\+=]+$',
+        regex=re.compile(r'^{FSHP[0123]\|[0-9]+\|[0-9]+}[a-z0-9\/\+=]+$', re.IGNORECASE),
         modes=[
             HashMode(name='Fairly Secure Hashed Password', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^\$PHPS\$.+\$[a-f0-9]{32}$',
+        regex=re.compile(r'^\$PHPS\$.+\$[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='PHPS', hashcat=2612, extended=False)]),
     Prototype(
-        regex=r'^[0-9]{4}:[a-f0-9]{16}:[a-f0-9]{2080}$',
+        regex=re.compile(r'^[0-9]{4}:[a-f0-9]{16}:[a-f0-9]{2080}$', re.IGNORECASE),
         modes=[
             HashMode(name='1Password(Agile Keychain)', hashcat=6600, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{64}:[a-f0-9]{32}:[0-9]{5}:[a-f0-9]{608}$',
+        regex=re.compile(r'^[a-f0-9]{64}:[a-f0-9]{32}:[0-9]{5}:[a-f0-9]{608}$', re.IGNORECASE),
         modes=[
             HashMode(name='1Password(Cloud Keychain)', hashcat=8200, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{256}:[a-f0-9]{256}:[a-f0-9]{16}:[a-f0-9]{16}:[a-f0-9]{320}:[a-f0-9]{16}:[a-f0-9]{40}:[a-f0-9]{40}:[a-f0-9]{32}$',
+        regex=re.compile(r'^[a-f0-9]{256}:[a-f0-9]{256}:[a-f0-9]{16}:[a-f0-9]{16}:[a-f0-9]{320}:[a-f0-9]{16}:[a-f0-9]{40}:[a-f0-9]{40}:[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='IKE-PSK MD5', hashcat=5300, extended=False)]),
     Prototype(
-        regex=r'^[a-f0-9]{256}:[a-f0-9]{256}:[a-f0-9]{16}:[a-f0-9]{16}:[a-f0-9]{320}:[a-f0-9]{16}:[a-f0-9]{40}:[a-f0-9]{40}:[a-f0-9]{40}$',
+        regex=re.compile(r'^[a-f0-9]{256}:[a-f0-9]{256}:[a-f0-9]{16}:[a-f0-9]{16}:[a-f0-9]{320}:[a-f0-9]{16}:[a-f0-9]{40}:[a-f0-9]{40}:[a-f0-9]{40}$', re.IGNORECASE),
         modes=[
             HashMode(name='IKE-PSK SHA1', hashcat=5400, extended=False)]),
     Prototype(
-        regex=r'^[a-z0-9+\/]{27}=$',
+        regex=re.compile(r'^[a-z0-9+\/]{27}=$', re.IGNORECASE),
         modes=[
             HashMode(name='PeopleSoft', hashcat=133, extended=False)]),
     Prototype(
-        regex=r'^crypt\$[a-f0-9]{5}\$[a-z0-9.\/]{13}$',
+        regex=re.compile(r'^crypt\$[a-f0-9]{5}\$[a-z0-9.\/]{13}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(DES Crypt Wrapper)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^pbkdf2_sha256\$[0-9]+\$[a-z0-9]{1,}\$[a-z0-9+\/]{43}=$',
+        regex=re.compile(r'^pbkdf2_sha256\$[0-9]+\$[a-z0-9]{1,}\$[a-z0-9+\/]{43}=$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(PBKDF2-HMAC-SHA256)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^pbkdf2_sha1\$[0-9]+\$[a-z0-9]{1,}\$[a-z0-9+\/]{27}=$',
+        regex=re.compile(r'^pbkdf2_sha1\$[0-9]+\$[a-z0-9]{1,}\$[a-z0-9+\/]{27}=$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(PBKDF2-HMAC-SHA1)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^bcrypt(\$2[axy]|\$2)\$[0-9]{0,2}?\$[a-z0-9\/\.]{53}$',
+        regex=re.compile(r'^bcrypt(\$2[axy]|\$2)\$[0-9]{0,2}?\$[a-z0-9\/\.]{53}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(BCrypt)', hashcat=None, extended=False)]),
     Prototype(
-        regex=r'^md5\$[a-f0-9]{1,}\$[a-f0-9]{32}$',
+        regex=re.compile(r'^md5\$[a-f0-9]{1,}\$[a-f0-9]{32}$', re.IGNORECASE),
         modes=[
             HashMode(name='Django(MD5)', hashcat=None, extended=False)])
 ]
@@ -635,8 +635,8 @@ class HashID(object):
     def identifyHash(self, phash):
         """return algorithm and hashcat mode"""
         phash = phash.strip()
-        for prototype in prototypes:
-            if (re.match(prototype.regex, phash, re.IGNORECASE)):
+        for prototype in self.prototypes:
+            if prototype.regex.match(phash):
                 for mode in prototype.modes:
                     yield mode
 


### PR DESCRIPTION
Reimplemented re.compile() implementation without json file. All the `re.compile()` calls are in the `prototypes=[...]` definition again.

Also fix a missing `self` in identifyHash().

I added `u` to some strings to allow "≥" in literals for Python 2.7. This is needed if the `str.format()` calls are on  a unicode literal.
